### PR TITLE
feat: Move Code of Conduct to kedacore/governance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,3 @@
 # Code of Conduct
 
-KEDA is a CNCF project and follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to a project maintainer.
+KEDA is a CNCF project and has defined a [Code of Conduct](https://github.com/kedacore/governance/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Move Code of Conduct to kedacore/governance to centralize things

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/governance/issues/86
